### PR TITLE
Preset view

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,6 +2,29 @@
 
 LivePose lets you run computer vision models on live video and stream the results over OSC.
 
+## Presets (recommended)
+
+The fastest way to get going is the **PRESETS** view in the sidebar. It lists
+ready-made Pose Detector configurations grouped by category (body, hand, face,
+animal, box detection, tracking & re-ID), with a live preview on the right.
+Clicking one fills in the Run settings — model files, workflow, tracking and
+re-ID parameters — so you can press **Start** right there.
+
+Presets are **read from the model pack(s) on disk**, so each pack brings its own
+presets and the models they need:
+
+- Set the **Models / Packs Folder** at the top of the PRESETS view (a sensible
+  default is provided; use **Browse** to change it). It can point at a single
+  pack, the `packages` folder holding several packs, or a library root — LivePose
+  scans them all.
+- Click **Get models…** to open the
+  [model-storage release](https://github.com/sat-mtl/livepose/releases/tag/model-storage),
+  download a pack (`onnx-models-large.7z` for everything, `onnx-models.7z` for a
+  smaller subset), and extract it into that folder. Press **Rescan**.
+
+A green dot next to a preset means its models are present on disk; a grey dot
+("models missing") means that pack's models still need downloading.
+
 ## Loading a model
 
 - Click **Browse** next to **ONNX Model File** and select an `.onnx` file

--- a/qml/Main.qml
+++ b/qml/Main.qml
@@ -23,6 +23,10 @@ ApplicationWindow {
 
         property string poseDetectorModelPath: ""
 
+        // Folder the preset model paths (<LIBRARY>:packages/pose-detector/…) are
+        // rewritten to. Empty = use PresetView's computed default.
+        property string poseDetectorModelsFolder: ""
+
         property string oscIpAddress: "127.0.0.1"
         property string oscPortValue: "9000"
         property string lastVideoPath: ""
@@ -119,7 +123,8 @@ ApplicationWindow {
     
     property int currentViewIndex: 0
     readonly property int runViewIndex: 0
-    readonly property int logViewIndex: 1
+    readonly property int presetsViewIndex: 1
+    readonly property int logViewIndex: 2
 
     AboutDialog {
         id: aboutDialog
@@ -170,7 +175,16 @@ ApplicationWindow {
                     isActive: currentViewIndex === runViewIndex
                     onClicked: currentViewIndex = runViewIndex
                 }
-                
+
+                CustomButton {
+                    id: presetsButton
+                    text: "PRESETS"
+                    Layout.fillWidth: true
+                    Layout.topMargin: appStyle.spacing
+                    isActive: currentViewIndex === presetsViewIndex
+                    onClicked: currentViewIndex = presetsViewIndex
+                }
+
                 CustomButton {
                     id: logButton
                     text: "LOGS"
@@ -192,7 +206,8 @@ ApplicationWindow {
             Layout.fillHeight: true
             currentIndex: currentViewIndex
             
-            RunView { }
+            RunView { id: runViewItem }
+            PresetView { runView: runViewItem }
             LogView { }
         }
     }

--- a/qml/livepose/Components/PreviewPanel.qml
+++ b/qml/livepose/Components/PreviewPanel.qml
@@ -1,0 +1,110 @@
+import QtQuick
+import QtQuick.Controls.Basic
+import QtQuick.Layouts
+import Score.UI as UI
+import livepose
+
+// Live video preview + transport, shared by the RUN and PRESETS views. All
+// pipeline state and actions are delegated to `target` (a RunView), so the
+// preview is identical wherever it appears and a preset clicked in the PRESETS
+// view shows up in this preview immediately.
+Item {
+    id: root
+
+    property var target
+
+    // Whether THIS panel owns the live preview. Exactly one PreviewPanel may be
+    // active at a time: two TextureSources on the same GFX process spin up two
+    // render lists, each re-initialising the Pose Detector's ONNX session, which
+    // crashes. The views set this so only the visible preview renders.
+    property bool active: true
+
+    readonly property bool running: target ? target.isRunning : false
+    readonly property bool paused: target ? target.isPaused : false
+
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: appStyle.spacing
+
+        CustomLabel {
+            text: "Video Preview"
+            font.bold: true
+            font.pixelSize: appStyle.fontSizeSubtitle
+        }
+
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.preferredHeight: width / aspectRatio
+            Layout.minimumWidth: 360
+            Layout.minimumHeight: 200
+            color: "transparent"
+            radius: appStyle.borderRadius
+            border.color: appStyle.borderColor
+            border.width: 1
+
+            readonly property real aspectRatio: 16 / 9
+            Rectangle {
+                anchors.fill: parent
+                anchors.margins: 1
+                radius: appStyle.borderRadius - 1
+                color: appStyle.backgroundColorTertiary
+                clip: true
+                layer.enabled: true
+                layer.smooth: true
+
+                UI.TextureSource {
+                    id: textureSource
+                    width: 1280
+                    height: 720
+                    process: (root.active && root.running) ? "livepose preview" : ""
+                    port: 0
+                    visible: root.active && root.running
+                }
+                ShaderEffectSource {
+                    anchors.fill: parent
+                    sourceItem: textureSource
+                    hideSource: true
+                }
+                Text {
+                    anchors.centerIn: parent
+                    text: root.target ? root.target.statusText : ""
+                    color: appStyle.textColorSecondary
+                    font.family: appStyle.fontFamily
+                    font.pixelSize: appStyle.fontSizeBody
+                    visible: !root.running
+                }
+            }
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+
+            Button {
+                text: root.running ? "Stop" : "Start"
+                font.family: appStyle.fontFamily
+                font.pixelSize: appStyle.fontSizeBody
+                onClicked: {
+                    if (!root.target) return
+                    if (root.running) root.target.stopCurrentProcess()
+                    else root.target.startTriggeredScenario()
+                }
+            }
+
+            Button {
+                text: root.paused ? "Resume" : "Pause"
+                visible: root.running
+                font.family: appStyle.fontFamily
+                font.pixelSize: appStyle.fontSizeBody
+                onClicked: if (root.target) root.target.togglePause()
+            }
+
+            CustomLabel {
+                Layout.fillWidth: true
+                wrapMode: Text.WordWrap
+                text: root.target ? root.target.statusText : ""
+            }
+        }
+
+        Item { Layout.fillHeight: true }
+    }
+}

--- a/qml/livepose/Views/PresetView.qml
+++ b/qml/livepose/Views/PresetView.qml
@@ -1,0 +1,372 @@
+import QtQuick
+import QtQuick.Controls.Basic
+import QtQuick.Layouts
+import QtCore
+import QtQuick.Dialogs
+import livepose
+
+Pane {
+    id: presetView
+    background: Rectangle { color: appStyle.backgroundColor }
+
+    // The RunView instance the presets are applied to (wired up in Main.qml).
+    property var runView: null
+
+    // Bumped to re-evaluate "are the models on disk?" checks.
+    property int refreshKey: 0
+
+    // Presets discovered from the pack(s) on disk (not bundled with the app, so
+    // any model pack — now or later — brings its own presets).
+    property var presetsList: []
+    property var byCategory: ({})
+    property var categoryOrder: []
+
+    // Preferred menu order; categories outside this list are appended after.
+    readonly property var preferredOrder: [
+        "Body/Single-stage", "Body/Two-stage", "Body/Whole-frame", "Body/3D",
+        "Hand", "Face/Landmarks", "Face/Detection", "Animal",
+        "Detection (boxes)", "Tracking & Re-ID"
+    ]
+
+    readonly property string downloadUrl: "https://github.com/sat-mtl/livepose/releases/tag/model-storage"
+
+    // Where the packs live. Points at the score-style "packages" folder by
+    // default; discovery also accepts a single pack folder or a library root.
+    readonly property string defaultModelsFolder:
+        urlToLocalPath(StandardPaths.writableLocation(StandardPaths.DocumentsLocation))
+        + "/SAT/LivePose/packages"
+
+    readonly property string modelsFolder:
+        modelsFolderField.text !== "" ? modelsFolderField.text : defaultModelsFolder
+
+    function urlToLocalPath(u) {
+        var s = "" + u
+        if (s.indexOf("file://") === 0) s = s.substring("file://".length)
+        if (Qt.platform.os === "windows" && s.length > 1 && s.charAt(0) === "/")
+            s = s.substring(1)
+        return decodeURIComponent(s)
+    }
+
+    function dirName(p) {
+        var i = p.lastIndexOf("/")
+        return i > 0 ? p.substring(0, i) : p
+    }
+
+    // Util.readFile returns the raw bytes; decode to text for JSON.parse.
+    function readText(path) {
+        var data = Util.readFile(path)
+        if (data === undefined || data === null) return ""
+        if (typeof data === "string") return data
+        try {
+            var u8 = new Uint8Array(data)
+            var s = ""
+            for (var i = 0; i < u8.length; i++) s += String.fromCharCode(u8[i])
+            return s
+        } catch (e) {
+            return "" + data
+        }
+    }
+
+    // Every "<pack>/presets/PoseDetector" dir reachable from `root`, whether it
+    // points at a single pack, a packages dir, or a library root.
+    function presetDirs(root) {
+        var dirs = []
+        function add(dir) {
+            var pd = dir + "/presets/PoseDetector"
+            if (Util.isDir(pd) && dirs.indexOf(pd) < 0) dirs.push(pd)
+        }
+        add(root)
+        var subs = Util.listDirectories(root)
+        for (var i = 0; i < subs.length; i++) add(subs[i])
+        if (Util.isDir(root + "/packages")) {
+            var subs2 = Util.listDirectories(root + "/packages")
+            for (var j = 0; j < subs2.length; j++) add(subs2[j])
+        }
+        return dirs
+    }
+
+    function discover() {
+        var list = []
+        var dirs = presetDirs(modelsFolder)
+        for (var d = 0; d < dirs.length; d++) {
+            var packDir = dirName(dirName(dirs[d]))   // <pack>/presets/PoseDetector -> <pack>
+            var files = Util.listFiles(dirs[d], "*.scp")
+            for (var f = 0; f < files.length; f++) {
+                try {
+                    var obj = JSON.parse(readText(files[f]))
+                    var pr = obj.Preset || []
+                    var models = []
+                    for (var v = 0; v < pr.length; v++) {
+                        var id = pr[v][0], wrap = pr[v][1]
+                        if ((id === 1 || id === 7 || id === 14) && wrap && wrap.String
+                                && ("" + wrap.String).indexOf(".onnx") >= 0)
+                            models.push(wrap.String)
+                    }
+                    list.push({
+                        name: obj.Name || files[f],
+                        category: obj.Category || "Uncategorized",
+                        values: pr,
+                        models: models,
+                        packDir: packDir
+                    })
+                } catch (e) {
+                    mainWindow.logger.log("Preset parse failed: " + files[f])
+                }
+            }
+        }
+
+        list.sort(function(a, b) {
+            var ca = preferredOrder.indexOf(a.category); if (ca < 0) ca = 999
+            var cb = preferredOrder.indexOf(b.category); if (cb < 0) cb = 999
+            if (ca !== cb) return ca - cb
+            var na = a.name.toLowerCase(), nb = b.name.toLowerCase()
+            return na < nb ? -1 : (na > nb ? 1 : 0)
+        })
+
+        var grp = ({}), order = []
+        for (var k = 0; k < list.length; k++) {
+            var c = list[k].category
+            if (!grp[c]) { grp[c] = []; order.push(c) }
+            grp[c].push(list[k])
+        }
+        presetsList = list
+        byCategory = grp
+        categoryOrder = order
+        refreshKey++
+    }
+
+    // A preset is "ready" when every model it references exists under its pack.
+    function presetReady(preset) {
+        if (!preset.models || preset.models.length === 0) return false
+        if (!runView) return false
+        for (var i = 0; i < preset.models.length; i++) {
+            var path = runView.resolvePresetPath(preset.models[i], preset.packDir)
+            if (!path || !Util.fileExists(path)) return false
+        }
+        return true
+    }
+
+    function readyCount() {
+        var n = 0
+        for (var i = 0; i < presetsList.length; i++)
+            if (presetReady(presetsList[i])) n++
+        return n
+    }
+
+    Component.onCompleted: {
+        modelsFolderField.text = appSettings.poseDetectorModelsFolder
+        if (modelsFolderField.text === "")
+            modelsFolderField.text = defaultModelsFolder
+        discover()
+    }
+
+    onVisibleChanged: if (visible) discover()
+
+    FolderDialog {
+        id: modelsFolderDialog
+        title: "Select Models / Packs Folder"
+        onAccepted: {
+            if (!selectedFolder) return
+            modelsFolderField.text = urlToLocalPath(selectedFolder)
+            discover()
+        }
+    }
+
+    SplitView {
+        anchors.fill: parent
+        orientation: Qt.Horizontal
+        handle: Rectangle {
+            implicitWidth: 3
+            color: SplitHandle.pressed ? appStyle.primaryColor
+                 : SplitHandle.hovered ? appStyle.borderColor : appStyle.separatorColor
+        }
+
+        ScrollView {
+            SplitView.fillWidth: true
+            SplitView.minimumWidth: 380
+            contentWidth: availableWidth
+
+            ColumnLayout {
+                x: appStyle.padding
+                width: parent.width - 2 * appStyle.padding
+                spacing: appStyle.spacing * 0.75
+
+                CustomLabel {
+                    text: "Presets"
+                    font.bold: true
+                    font.pixelSize: appStyle.fontSizeSubtitle
+                    Layout.topMargin: appStyle.padding
+                }
+
+                CustomLabel {
+                    Layout.fillWidth: true
+                    wrapMode: Text.WordWrap
+                    color: appStyle.textColorSecondary
+                    font.pixelSize: appStyle.fontSizeSmall
+                    text: "Presets are read from the model pack(s) on disk. Click one to "
+                        + "fill in the Run settings, then press Start — the preview is on "
+                        + "the right."
+                }
+
+                CustomLabel { text: "Models / Packs Folder"; font.bold: true; Layout.topMargin: appStyle.spacing }
+
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: appStyle.spacing
+
+                    CustomTextField {
+                        id: modelsFolderField
+                        Layout.fillWidth: true
+                        placeholderText: presetView.defaultModelsFolder
+                        onTextChanged: {
+                            appSettings.poseDetectorModelsFolder = text
+                            presetView.refreshKey++
+                        }
+                        onEditingFinished: presetView.discover()
+                    }
+
+                    Button {
+                        text: "Browse"
+                        font.family: appStyle.fontFamily
+                        font.pixelSize: appStyle.fontSizeBody
+                        onClicked: modelsFolderDialog.open()
+                    }
+
+                    Button {
+                        text: "Rescan"
+                        font.family: appStyle.fontFamily
+                        font.pixelSize: appStyle.fontSizeBody
+                        onClicked: presetView.discover()
+                    }
+
+                    Button {
+                        text: "Get models…"
+                        font.family: appStyle.fontFamily
+                        font.pixelSize: appStyle.fontSizeBody
+                        onClicked: Qt.openUrlExternally(presetView.downloadUrl)
+                    }
+                }
+
+                CustomLabel {
+                    Layout.fillWidth: true
+                    wrapMode: Text.WordWrap
+                    font.pixelSize: appStyle.fontSizeSmall
+                    color: presetView.presetsList.length === 0 ? appStyle.errorColor
+                                                               : appStyle.textColorSecondary
+                    text: {
+                        presetView.refreshKey
+                        if (presetView.presetsList.length === 0)
+                            return "No presets found under this folder. Download a model pack "
+                                + "via “Get models…”, extract it here, then press Rescan."
+                        return presetView.readyCount() + " / " + presetView.presetsList.length
+                            + " presets have their models on disk."
+                    }
+                }
+
+                Rectangle {
+                    Layout.fillWidth: true
+                    Layout.topMargin: appStyle.spacing * 0.5
+                    Layout.preferredHeight: 1
+                    color: appStyle.separatorColor
+                }
+
+                Repeater {
+                    model: presetView.categoryOrder
+
+                    ColumnLayout {
+                        required property string modelData
+                        Layout.fillWidth: true
+                        Layout.topMargin: appStyle.spacing
+                        spacing: appStyle.spacing * 0.5
+
+                        CustomLabel {
+                            text: modelData
+                            font.bold: true
+                            color: appStyle.textColorSecondary
+                        }
+
+                        Repeater {
+                            model: presetView.byCategory[modelData] || []
+
+                            Rectangle {
+                                id: card
+                                required property var modelData
+                                Layout.fillWidth: true
+                                implicitHeight: 36
+                                radius: appStyle.borderRadius
+                                color: cardMouse.containsMouse ? appStyle.backgroundColorTertiary
+                                                               : appStyle.backgroundColorSecondary
+                                border.width: 1
+                                border.color: cardMouse.containsMouse ? appStyle.primaryColor
+                                                                      : appStyle.borderColor
+
+                                readonly property bool ready: {
+                                    presetView.refreshKey
+                                    return presetView.presetReady(modelData)
+                                }
+
+                                RowLayout {
+                                    anchors.fill: parent
+                                    anchors.leftMargin: appStyle.spacing
+                                    anchors.rightMargin: appStyle.spacing
+                                    spacing: appStyle.spacing
+
+                                    Rectangle {
+                                        Layout.preferredWidth: 9
+                                        Layout.preferredHeight: 9
+                                        radius: 4.5
+                                        Layout.alignment: Qt.AlignVCenter
+                                        color: card.ready ? appStyle.buttonBgActive : appStyle.borderColor
+                                    }
+
+                                    CustomLabel {
+                                        Layout.fillWidth: true
+                                        text: card.modelData.name
+                                        elide: Text.ElideRight
+                                        color: card.ready ? appStyle.textColor : appStyle.textColorSecondary
+                                    }
+
+                                    CustomLabel {
+                                        text: "models missing"
+                                        visible: !card.ready
+                                        font.pixelSize: appStyle.fontSizeSmall
+                                        color: appStyle.textColorSecondary
+                                    }
+                                }
+
+                                MouseArea {
+                                    id: cardMouse
+                                    anchors.fill: parent
+                                    hoverEnabled: true
+                                    cursorShape: Qt.PointingHandCursor
+                                    onClicked: {
+                                        if (presetView.runView) {
+                                            presetView.runView.applyPreset(card.modelData.values,
+                                                                           card.modelData.packDir)
+                                            mainWindow.logger.log("Loaded preset: " + card.modelData.name)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Item { Layout.preferredHeight: appStyle.padding }
+            }
+        }
+
+        Item {
+            SplitView.preferredWidth: 480
+            SplitView.minimumWidth: 320
+
+            PreviewPanel {
+                anchors.fill: parent
+                anchors.margins: appStyle.padding
+                target: presetView.runView
+                // Owns the preview only while the PRESETS view is showing.
+                active: mainWindow.currentViewIndex === mainWindow.presetsViewIndex
+            }
+        }
+    }
+}

--- a/qml/livepose/Views/RunView.qml
+++ b/qml/livepose/Views/RunView.qml
@@ -2,7 +2,6 @@ import QtQuick
 import QtQuick.Controls.Basic
 import QtQuick.Layouts
 import QtCore
-import Score.UI as UI
 import livepose
 
 Pane {
@@ -32,7 +31,32 @@ Pane {
     property var modelPaths: ({})
     property string inputSource: "camera"
     property string videoFilePath: ""
-    
+
+    // Pure (side-effect-free) readiness/status, consumed by PreviewPanel so the
+    // RUN and PRESETS previews share one source of truth.
+    readonly property bool inputReady:
+        (inputSource === "camera" && cameraSelector.currentIndex > 0)
+        || (inputSource === "video" && videoFilePath !== "")
+    readonly property bool modelReady: {
+        if (!currentProcess) return false
+        return modelFilePathField.hasValidPath
+            || detectionModelFilePathField.text.indexOf(".onnx") >= 0
+    }
+    readonly property bool canStart: inputReady && modelReady
+    readonly property string statusText: {
+        if (!currentProcess) return "Please select a model"
+        if (!modelReady) return "Please select a Landmark or Detection model"
+        if (!inputReady) return (inputSource === "camera")
+            ? "Please select a camera" : "Please select a video file"
+        if (isRunning) return (isPaused ? "Paused: " : "Running: ") + currentProcess.scenarioLabel
+        return "Ready: " + currentProcess.scenarioLabel
+    }
+
+    function togglePause() {
+        if (isPaused) { Score.resume(); isPaused = false }
+        else { Score.pause(); isPaused = true }
+    }
+
     property var poseDetectorWorkflows: [
         "Auto",
         "BlazePose",
@@ -110,6 +134,104 @@ Pane {
         try {
             if (video_in.process_object) video_in.process_object.path = path
         } catch(e) { }
+    }
+
+    // Resolve a preset model path against the pack it came from. Presets
+    // reference models with the macro "<LIBRARY>:packages/<pack>/<sub>/<model>.onnx";
+    // on disk that pack lives at packDir, so we drop the
+    // "<LIBRARY>:packages/<pack>/" prefix and hang the rest off packDir. This is
+    // pack-name agnostic, so any installed model pack resolves.
+    function resolvePresetPath(p, packDir) {
+        if (!p) return ""
+        var marker = "<LIBRARY>:packages/"
+        if (p.indexOf(marker) === 0) {
+            var rest = p.substring(marker.length)      // "<pack>/<sub>/<model>.onnx"
+            var slash = rest.indexOf("/")
+            return packDir + "/" + (slash >= 0 ? rest.substring(slash + 1) : rest)
+        }
+        if (p.indexOf("<LIBRARY>:") === 0)
+            return packDir + "/" + p.substring("<LIBRARY>:".length)
+        return p
+    }
+
+    // Apply a preset (the .scp "Preset" array, read from the pack by PresetView)
+    // by driving the existing UI widgets. Each widget's handler already pushes to
+    // the score process and persists to appSettings, so this is the single source
+    // of truth and works whether or not the pipeline is currently running.
+    // Score.loadPreset would set the C++ ports but leave these fields stale, so we
+    // do NOT use it. packDir is the on-disk pack the preset's models resolve against.
+    function applyPreset(values, packDir) {
+        if (!values) return
+
+        // Flatten [[id, {Type: value}], ...] into id -> raw value.
+        var v = ({})
+        for (var i = 0; i < values.length; i++) {
+            var id = values[i][0]
+            var wrap = values[i][1]
+            for (var k in wrap) { v[id] = wrap[k]; break }
+        }
+        function has(id) { return v[id] !== undefined }
+
+        function setCombo(sel, model, val) {
+            // Enum controls are stored either as an integer index (workflow,
+            // motion gate, skeleton type) or as the string label (output mode,
+            // data format, re-id preprocess). Handle both.
+            var idx = (typeof val === "number") ? val : model.indexOf(val)
+            if (idx >= 0 && idx < model.length) sel.currentIndex = idx
+        }
+
+        // Workflow first: it drives backendSelector, whose handler resets the
+        // model path field — so the model paths below must be applied afterwards.
+        if (has(2)) {
+            var w = (typeof v[2] === "number") ? v[2] : poseDetectorWorkflows.indexOf(v[2])
+            if (w >= 0 && w < poseDetectorWorkflows.length) backendSelector.currentIndex = w + 1
+        }
+
+        // Model file ports (rewrite <LIBRARY> -> models folder).
+        if (has(1)) modelFilePathField.text = resolvePresetPath(String(v[1]), packDir)
+        if (has(7)) detectionModelFilePathField.text = resolvePresetPath(String(v[7]), packDir)
+        if (has(14)) reidModelFilePathField.text = resolvePresetPath(String(v[14]), packDir)
+        if (has(26)) classNamesFilePathField.text = resolvePresetPath(String(v[26]), packDir)
+
+        // Enum combo boxes.
+        if (has(3)) setCombo(outputModeSelector, poseDetectorOutputModes, v[3])
+        if (has(6)) setCombo(dataFormatSelector, poseDetectorDataFormats, v[6])
+        if (has(17)) setCombo(reidPreprocessSelector, poseDetectorReidPreprocess, v[17])
+        if (has(21)) setCombo(motionGateSelector, poseDetectorMotionGates, v[21])
+        if (has(25)) setCombo(skeletonTypeSelector, poseDetectorSkeletonTypes, v[25])
+
+        // Float sliders.
+        if (has(4)) minConfidenceSlider.value = v[4]
+        if (has(10)) smoothingAmountSlider.value = v[10]
+        if (has(16)) reidWeightSlider.value = v[16]
+        if (has(22)) maxSpeedSlider.value = v[22]
+        if (has(29)) reidMarginSlider.value = v[29]
+
+        // Int spin boxes.
+        if (has(12)) maxInstancesSpinBox.value = v[12]
+        if (has(13)) detectorCadenceSpinBox.value = v[13]
+        if (has(19)) detectionClassSpinBox.value = v[19]
+        if (has(27)) trackMemorySpinBox.value = v[27]
+        if (has(28)) reidMemorySpinBox.value = v[28]
+        if (has(30)) holdFramesSpinBox.value = v[30]
+
+        // Bool check boxes.
+        if (has(5)) drawSkeletonSwitch.checked = v[5]
+        if (has(8)) trackROISwitch.checked = v[8]
+        if (has(9)) smoothingSwitch.checked = v[9]
+        if (has(11)) trackIDsSwitch.checked = v[11]
+        if (has(15)) reidSwitch.checked = v[15]
+        if (has(18)) drawBoxesSwitch.checked = v[18]
+        if (has(20)) drawLandmarksSwitch.checked = v[20]
+        if (has(23)) birthGateSwitch.checked = v[23]
+        if (has(24)) strictConfirmSwitch.checked = v[24]
+
+        // If a pipeline is already running, restart it so the new models load
+        // and the live preview reflects the preset immediately. (A workflow
+        // change above already triggers one restart; this covers model-only
+        // changes, and restartIfRunning is a no-op once stopped, so we restart
+        // exactly once.)
+        if (isRunning) restartIfRunning()
     }
 
     Item {
@@ -209,17 +331,13 @@ Pane {
             showModelError = true
             return false
         }
-        // BoxDetection runs the Detection Model only (no landmark stage), so it
-        // requires a Detection Model rather than the Landmark Model.
-        var isBoxDetection = currentProcess.isPoseDetector && currentProcess.scenarioLabel === "BoxDetection"
-        if (isBoxDetection) {
-            if (detectionModelFilePathField.text.indexOf(".onnx") < 0) {
-                logger.log("Cannot start: BoxDetection needs a Detection Model (.onnx)")
-                showModelFileError = true
-                return false
-            }
-        } else if (!modelFilePathField.hasValidPath) {
-            logger.log("Cannot start: No ONNX model file selected")
+        // A Landmark model drives single/two-stage pose; a Detection model alone
+        // drives box detection. Either one is enough — Auto picks the pipeline,
+        // and several box presets ship with only a Detection model set.
+        var hasLandmark = modelFilePathField.hasValidPath
+        var hasDetection = detectionModelFilePathField.text.indexOf(".onnx") >= 0
+        if (!hasLandmark && !hasDetection) {
+            logger.log("Cannot start: select a Landmark or Detection model (.onnx)")
             showModelFileError = true
             return false
         }
@@ -1288,122 +1406,13 @@ Pane {
             SplitView.preferredWidth: 480
             SplitView.minimumWidth: 320
 
-            ColumnLayout {
+            PreviewPanel {
                 anchors.fill: parent
                 anchors.margins: appStyle.padding
-                spacing: appStyle.spacing
-
-                CustomLabel {
-                    text: "Video Preview"
-                    font.bold: true
-                    font.pixelSize: appStyle.fontSizeSubtitle
-                }
-
-                Rectangle {
-                    id: videoPreviewFrame
-                    Layout.fillWidth: true
-                    Layout.preferredHeight: width / aspectRatio
-                    Layout.minimumWidth: 360
-                    Layout.minimumHeight: 200
-                    color: "transparent"
-                    radius: appStyle.borderRadius
-                    border.color: appStyle.borderColor
-                    border.width: 1
-
-                    readonly property real aspectRatio: 16 / 9
-                    Rectangle {
-                        id: videoPreviewClip
-                        anchors.fill: parent
-                        anchors.margins: 1
-                        radius: appStyle.borderRadius - 1
-                        color: appStyle.backgroundColorTertiary
-                        clip: true
-                        layer.enabled: true
-                        layer.smooth: true
-
-                        UI.TextureSource {
-                            id: textureSource
-                            width: 1280
-                            height: 720
-                            process: isRunning ? "livepose preview" : ""
-                            port: 0
-                            visible: isRunning
-                        }
-                        ShaderEffectSource {
-                            anchors.fill: parent
-                            sourceItem: textureSource
-                            hideSource: true
-                        }
-                        Text {
-                            anchors.centerIn: parent
-                            text: {
-                                if (!currentProcess) {
-                                    return "Please select a model"
-                                } else if (!modelFilePathField.hasValidPath) {
-                                    return "Please select an ONNX model file"
-                                } else if (cameraSelector.currentIndex <= 0) {
-                                    return "Please select a camera"
-                                } else {
-                                    return "Ready to start: " + currentProcess.scenarioLabel
-                                }
-                            }
-                            color: appStyle.textColorSecondary
-                            font.family: appStyle.fontFamily
-                            font.pixelSize: appStyle.fontSizeBody
-                            visible: !isRunning
-                        }
-                    }
-                }
-
-                RowLayout {
-                    Layout.fillWidth: true
-
-                    Button {
-                        id: startStopButton
-                        text: isRunning ? "Stop" : "Start"
-                        font.family: appStyle.fontFamily
-                        font.pixelSize: appStyle.fontSizeBody
-                        onClicked: {
-                            if (isRunning) {
-                                stopCurrentProcess()
-                            } else {
-                                if (validateBeforeStart()) {
-                                    startTriggeredScenario()
-                                }
-                            }
-                        }
-                    }
-
-                    Button {
-                        text: isPaused ? "Resume" : "Pause"
-                        visible: isRunning
-                        font.family: appStyle.fontFamily
-                        font.pixelSize: appStyle.fontSizeBody
-                        onClicked: {
-                            if (isPaused) {
-                                Score.resume()
-                                isPaused = false
-                            } else {
-                                Score.pause()
-                                isPaused = true
-                            }
-                        }
-                    }
-
-                    CustomLabel {
-                        Layout.fillWidth: true
-                        wrapMode: Text.WordWrap
-                        text: {
-                            if (!currentProcess) return "Please select a model"
-                            if (!modelFilePathField.hasValidPath) return "Please select an ONNX model file"
-                            if (cameraSelector.currentIndex <= 0) return "Please select a camera"
-                            if (isRunning) return (isPaused ? "Paused: " : "Running: ") + currentProcess.scenarioLabel
-                            return "Ready: " + currentProcess.scenarioLabel
-                        }
-                    }
-                }
-
-                Item { Layout.fillHeight: true }
+                target: runView
+                // Owns the preview on every view except PRESETS (which has its
+                // own); this keeps inference/OSC alive on the RUN and LOGS views.
+                active: mainWindow.currentViewIndex !== mainWindow.presetsViewIndex
             }
         }
     }

--- a/qml/livepose/qmldir
+++ b/qml/livepose/qmldir
@@ -7,5 +7,7 @@ CustomLabel 1.0 Components/CustomLabel.qml
 CustomSwitch 1.0 Components/CustomSwitch.qml
 CustomTextField 1.0 Components/CustomTextField.qml
 AboutDialog 1.0 Components/AboutDialog.qml
+PreviewPanel 1.0 Components/PreviewPanel.qml
 RunView 1.0 Views/RunView.qml
+PresetView 1.0 Views/PresetView.qml
 LogView 1.0 Views/LogView.qml


### PR DESCRIPTION
Stacked on top of #66 — base branch is `feature/onnx-pose`, so this diff is just the preset view.

Adds a **PRESETS** view: ready-made Pose Detector configurations discovered from the model pack(s) on disk, with a live preview.

## What it does
- New sidebar **PRESETS** view — split list + live preview with Start/Stop/Pause.
- Presets are **read at runtime** from each pack's `presets/PoseDetector/*.scp` (not bundled in the app), grouped by category. Multiple packs are supported; a green/grey dot shows whether each preset's models are on disk.
- Clicking a preset fills in the Run settings; if a pipeline is running it reloads so the change shows immediately.
- **Models / Packs Folder** picker (a single pack, a `packages` dir, or a library root all resolve), a **Rescan** button, and **Get models…** linking the [model-storage release](https://github.com/sat-mtl/livepose/releases/tag/model-storage).
- Each preset's `<LIBRARY>:packages/<pack>/…` models resolve against the pack it was read from (pack-name agnostic).

## Notable fixes
- Extracted the video preview into a shared `PreviewPanel` reused by RUN and PRESETS; **only the visible view's `TextureSource` renders** — two on one GFX process double-init the Pose Detector's ONNX session and crash.
- Allow starting with a **Detection model alone** (Auto box detection), which the box-detection presets (FaceBoxes, RetinaFace, …) rely on.

## Dependency
Runtime discovery uses `Util.listFiles` / `Util.listDirectories`, added to ossia/score master (`db7443f3f`). livepose CI builds score master, so it needs that commit upstream — already pushed. No `score-addon-onnx` changes were needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_011Xfe2aAPp5U9X37NbqhYLF
