### PR TITLE
ci: build Intel macOS and ARM Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,16 +19,28 @@ jobs:
           - os: ubuntu-latest
             platform: linux-x86_64
             artifact-name: linux-x86_64
+          - os: ubuntu-24.04-arm
+            platform: linux-aarch64
+            artifact-name: linux-aarch64
           - os: macos-latest
             platform: macos-arm
             artifact-name: macos-arm
+          - os: macos-latest
+            platform: macos-intel
+            artifact-name: macos-intel
+            target-arch: x86_64
           - os: windows-latest
             platform: windows
             artifact-name: windows
+          - os: ubuntu-24.04
+            platform: wasm
+            artifact-name: wasm
+            target-platform: wasm
+            artifact-path: packages/*.zip
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Build ossia score from master: its ci/common.deps.sh clones
       # score-addon-onnx (the pose detector landed on the addon's default
@@ -50,6 +62,7 @@ jobs:
             -DSCORE_QT_PLUGINS_NO_QTQUICK3D=1
             -DSCORE_QT_PLUGINS_NO_IMAGEFORMATS=1
           target-arch: ${{ matrix.target-arch || '' }}
+          target-platform: ${{ matrix.target-platform || '' }}
           macos-certificate-base64: ${{ secrets.MAC_CERT_B64 }}
           macos-certificate-password: ${{ secrets.MAC_CERT_PASSWORD }}
           macos-notarize-team-id: ${{ secrets.MAC_NOTARIZE_TEAM_ID }}
@@ -89,7 +102,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: livepose-${{ matrix.artifact-name }}
-          path: packages/
+          path: ${{ matrix.artifact-path || 'packages/' }}
           retention-days: 30
 
   release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,9 @@ jobs:
           - os: windows-latest
             platform: windows
             artifact-name: windows
+          - os: windows-11-arm
+            platform: windows-arm64
+            artifact-name: windows-arm64
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,11 +32,6 @@ jobs:
           - os: windows-latest
             platform: windows
             artifact-name: windows
-          - os: ubuntu-24.04
-            platform: wasm
-            artifact-name: wasm
-            target-platform: wasm
-            artifact-path: packages/*.zip
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
LivePose shipped three packages — x86_64 Linux, Apple Silicon macOS, Windows. Intel Macs and ARM Linux machines got nothing, even though `create-app.sh` supports both.

| platform | runner | new |
|---|---|---|
| linux-x86_64 | ubuntu-latest | |
| linux-aarch64 | ubuntu-24.04-arm | ✅ |
| macos-arm | macos-latest | |
| macos-intel | macos-latest (cross) | ✅ |
| windows | windows-latest | |

ARM Linux runners are free for public repos. `macos-intel` cross-compiles via `target-arch: x86_64`, since `macos-latest` is ARM. `actions/checkout` v4 → v5 (v4 targets the deprecated Node 20).

## No wasm job here

I tried, and it does not link. LivePose is the only one of the four SAT apps pulling `score-addon-onnx`, and its prebuilt `libonnxruntime.a` statically embeds its own abseil, which collides with the copy libossia vendors:

```
wasm-ld: error: duplicate symbol: __em_js_ref_HaveOffsetConverter
>>> defined in 3rdparty/libossia/3rdparty/abseil-cpp/absl/debugging/libabsl_symbolize.a(symbolize.cc.o)
>>> defined in _deps/onnxruntime-src/lib/libonnxruntime.a(symbolize.cc.o)
```

Native linkers tolerate the duplicate; `wasm-ld` rejects duplicate `__em_js_*` symbols. The entire custom plugin set configures and compiles fine under emscripten — this is the final link step, and nothing in the workflow can route around it.

Building without the addon isn't worth shipping: the Pose Detector ports `RunView.qml` drives come from it, so the bundle would be LivePose minus pose detection.

For reference, the wasm path itself is sound — sat-mtl/DomeportPro#79 and sat-mtl/spatial-protocol-mapper#21 both produce a web bundle from a custom score build. Fixing this one means deduplicating abseil between onnxruntime and libossia, which belongs upstream in `score-addon-onnx`.

## Validation

All five platforms are exercised by this PR's run, against the merged ossia/score#2154 (package naming) and ossia/actions#24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VxtUwsfk4JN46WropbwfqC
